### PR TITLE
Used TextField instead of Input & InputLabel components

### DIFF
--- a/src/TextWidget/TextWidget.tsx
+++ b/src/TextWidget/TextWidget.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import FormControl from '@material-ui/core/FormControl';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 
 import { WidgetProps } from 'react-jsonschema-form';
 
@@ -36,9 +35,9 @@ const TextWidget = ({
       //error={!!rawErrors}
       required={required}
     >
-      <InputLabel>{label || schema.title}</InputLabel>
-      <Input
+      <TextField
         id={id}
+        label={label || schema.title}
         autoFocus={autofocus}
         required={required}
         disabled={disabled || readonly}

--- a/src/TextareaWidget/TextareaWidget.tsx
+++ b/src/TextareaWidget/TextareaWidget.tsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { WidgetProps } from 'react-jsonschema-form';
 
 import FormControl from '@material-ui/core/FormControl';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
+import TextField from '@material-ui/core/TextField';
 
 type CustomWidgetProps = WidgetProps & {
   options: any;
@@ -41,9 +40,9 @@ const TextareaWidget = ({
       //error={!!rawErrors}
       required={required}
     >
-      <InputLabel>{label || schema.title}</InputLabel>
-      <Input
+      <TextField
         id={id}
+        label={label || schema.title}
         placeholder={placeholder}
         disabled={disabled || readonly}
         value={value}


### PR DESCRIPTION
Hello dear maintainers/developers!

Recently, I found this awesome package and wanted to change some default props (like `variant`) of text widgets through [customizing mui default props](https://material-ui.com/customization/globals/#default-props).
But unfortunately, they were written using `Input` & `InputLabel` components and they didn't support some props like `variant` prop.

Now, I've just used `TextField` instead of `Input` & `InputLabel` for text & textarea widgets..!

Thanks for reading