### PR TITLE
propose fix for error messages in alternatives example 

### DIFF
--- a/example/src/examples/alternatives/schema.json
+++ b/example/src/examples/alternatives/schema.json
@@ -3,23 +3,8 @@
     "Color": {
       "title": "Color",
       "type": "string",
-      "anyOf": [
-        {
-          "type": "string",
-          "enum": ["#ff0000"],
-          "title": "Red"
-        },
-        {
-          "type": "string",
-          "enum": ["#00ff00"],
-          "title": "Green"
-        },
-        {
-          "type": "string",
-          "enum": ["#0000ff"],
-          "title": "Blue"
-        }
-      ]
+      "enum": ["#ff0000", "#00ff00", "#0000ff"],
+      "enumNames": ["Red", "Green", "Blue"]
     },
     "Toggle": {
       "title": "Toggle",


### PR DESCRIPTION
This is the fix for GH-88.

Context:
react-jsonschema-form has multiple ways to write a schema for enums as stated [here](https://react-jsonschema-form.readthedocs.io/en/latest/form-customization/#alternative-json-schema-compliant-approach)
The fix uses _enum_ and _enumNames_ instead of **anyOf**.
![image](https://user-images.githubusercontent.com/26364566/67395895-fd9fdf00-f5a6-11e9-91f9-39b27d656738.png)
