### PR TITLE
Select Widget Disable Fix

### DIFF
--- a/src/SelectWidget/SelectWidget.tsx
+++ b/src/SelectWidget/SelectWidget.tsx
@@ -75,6 +75,7 @@ const SelectWidget = ({
       fullWidth={true}
       //error={!!rawErrors}
       required={required}
+      disabled={disabled || readonly}
     >
       <InputLabel shrink={true} htmlFor={id}>
         {label || schema.title}


### PR DESCRIPTION
Now will apply proper disabled across full select, meaning the Material disabled classes make it to the label as well.